### PR TITLE
Release platform

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,17 +37,15 @@
 # is Garage, spoken to over the plain S3 protocol - see docker/garage/.
 # The credentials are the known development values garage-init provisions.
 #
-# @note the store is a separate, published service: the application reaches
-# it as garage:3900 inside the network, while browsers upload and download
-# through presigned URLs minted against STORAGE_PUBLIC_ENDPOINT - the
-# store's own name from the browser's point of view. Like the relay and the
-# app shells it gets a `*.localhost` name, which browsers resolve to loopback
-# with no DNS setup; set STORAGE_URL when the browser reaches the machine by
-# another address. (When running `pnpm dev` on the host instead,
-# STORAGE_ENDPOINT=http://localhost:3900 in platform/.env serves both roles.)
+# @note the store is a separate, published service with one name everywhere,
+# like the relay and the app shells: browsers resolve `cbk-storage.localhost`
+# to loopback with no DNS setup, and inside the network the garage service
+# carries it as an alias. Presigned URLs embed this endpoint and are fetched
+# by both browsers and the application itself, so the two must agree. (When
+# running `pnpm dev` on the host instead, STORAGE_ENDPOINT=http://localhost:3900
+# in platform/.env does the same job.)
 x-storage-env: &storage-env
-  STORAGE_ENDPOINT: http://garage:3900
-  STORAGE_PUBLIC_ENDPOINT: ${STORAGE_URL:-http://cbk-storage.localhost:${STORAGE_PORT:-3900}}
+  STORAGE_ENDPOINT: http://cbk-storage.localhost:3900
   STORAGE_REGION: garage
   STORAGE_ACCESS_KEY_ID: GK31e57eba9df26b2e7e1b0eaa
   STORAGE_SECRET_ACCESS_KEY: 9f3c1e2b8a4d5f6071829304a5b6c7d8e9f00112233445566778899aabbccdde
@@ -256,8 +254,13 @@ services:
     ports:
       # @note published on every interface: browsers talk to the store
       # directly through presigned URLs (see x-storage-env), and `pnpm dev`
-      # on the host uses the same port
-      - '${STORAGE_PORT:-3900}:3900'
+      # on the host uses the same port. Same port on both sides, so the one
+      # endpoint works from inside the network too
+      - '3900:3900'
+    networks:
+      default:
+        aliases:
+          - cbk-storage.localhost
     volumes:
       - ./docker/garage/garage.toml:/etc/garage.toml:ro
       - garage-data:/var/lib/garage

--- a/docker/distro/community/compose.yml
+++ b/docker/distro/community/compose.yml
@@ -30,16 +30,15 @@
 # volume (garage-init provisions it, the application entrypoint sources it);
 # set STORAGE_ACCESS_KEY_ID / STORAGE_SECRET_ACCESS_KEY to use a fixed pair.
 #
-# @note the store is a separate, published service: the application reaches
-# it as garage:3900 inside the network, while browsers upload and download
-# through presigned URLs minted against STORAGE_PUBLIC_ENDPOINT - the
-# store's own name from the browser's point of view. Like the relay and the
-# app shells it gets a `*.localhost` name, which browsers resolve to loopback
-# with no DNS setup; set STORAGE_URL to an address the browser can reach (and
-# TLS if the site has it) when that is not the machine itself.
+# @note the store is a separate, published service with one name everywhere,
+# like the relay and the app shells: browsers resolve `cbk-storage.localhost`
+# to loopback with no DNS setup, and inside the network the garage service
+# carries it as an alias on the same port (STORAGE_PORT). Presigned URLs embed
+# this endpoint and are fetched by both browsers and the application itself,
+# so the two must agree. Set STORAGE_URL to an address both can reach (and
+# TLS if the site has it) when browsers do not reach the machine itself.
 x-storage-env: &storage-env
-  STORAGE_ENDPOINT: http://garage:3900
-  STORAGE_PUBLIC_ENDPOINT: ${STORAGE_URL:-http://cbk-storage.localhost:${STORAGE_PORT:-3900}}
+  STORAGE_ENDPOINT: ${STORAGE_URL:-http://cbk-storage.localhost:${STORAGE_PORT:-3900}}
   STORAGE_REGION: garage
   STORAGE_ACCESS_KEY_ID: ${STORAGE_ACCESS_KEY_ID:-}
   STORAGE_SECRET_ACCESS_KEY: ${STORAGE_SECRET_ACCESS_KEY:-}
@@ -181,8 +180,13 @@ services:
       RUST_LOG: warn
     ports:
       # @note published on every interface: browsers talk to the store
-      # directly through presigned URLs (see x-storage-env)
-      - '${STORAGE_PORT:-3900}:3900'
+      # directly through presigned URLs (see x-storage-env). Same port on
+      # both sides, so the one endpoint works from inside the network too
+      - '${STORAGE_PORT:-3900}:${STORAGE_PORT:-3900}'
+    networks:
+      default:
+        aliases:
+          - cbk-storage.localhost
     configs:
       - source: garage-config
         target: /etc/garage.toml
@@ -208,7 +212,7 @@ services:
     environment:
       GARAGE_ADMIN_URL: http://garage:3903
       GARAGE_ADMIN_TOKEN: ${GARAGE_ADMIN_TOKEN:-dev-admin-token}
-      GARAGE_S3_URL: http://garage:3900
+      GARAGE_S3_URL: http://garage:${STORAGE_PORT:-3900}
       # @note origins allowed to use presigned URLs from a browser; the URLs
       # themselves are the access control
       STORAGE_CORS_ORIGINS: ${STORAGE_CORS_ORIGINS:-*}
@@ -251,7 +255,7 @@ configs:
       # @note the region is part of every SigV4 signature: STORAGE_REGION
       # must match it, or every request fails authentication
       s3_region = "garage"
-      api_bind_addr = "[::]:3900"
+      api_bind_addr = "[::]:${STORAGE_PORT:-3900}"
       root_domain = ".s3.garage.localhost"
 
       [admin]

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -140,9 +140,6 @@ services:
   platform:
     ports: !override
       - '3001:3000'
-  garage:
-    ports: !override
-      - '3901:3900'
 ```
 
 ```bash
@@ -153,8 +150,8 @@ docker compose -p cbk-staging \
 ```
 
 Set `SITE_URL` and `NEXTAUTH_URL` to the instance's published address
-(`http://localhost:3001` here) and `STORAGE_URL` to its store
-(`http://cbk-storage.localhost:3901`) - in the shell or through `--env-file`, since a
+(`http://localhost:3001` here) and `STORAGE_PORT` to a free store port
+(`3901`) - in the shell or through `--env-file`, since a
 single `.env` in the working directory cannot describe both instances. Volumes,
 networks and container names are all prefixed with the project name, so each
 instance keeps its own database, generated secrets, object store and vector
@@ -168,11 +165,12 @@ under `docker/distro/`; a future PostgreSQL flavor publishes as
 matching image flavor.
 
 Browser-facing file upload and download flows presign URLs against the
-in-stack store, which the stack publishes on port 3900 (`STORAGE_PORT`) under
-its own name: the URLs are minted against `STORAGE_PUBLIC_ENDPOINT`,
-`http://cbk-storage.localhost:3900` by default, a `*.localhost` name browsers
-resolve to loopback like the relay and app shells. Set `STORAGE_URL` to the
-address browsers actually reach the host on (with TLS if the site has it). `garage-init` grants every bucket a CORS
+in-stack store, published on port 3900 (`STORAGE_PORT`) under one name,
+`http://cbk-storage.localhost:3900`: a `*.localhost` name browsers resolve to
+loopback like the relay and app shells, and an alias of the `garage` service
+inside the Compose network, since the application fetches the same URLs. Set
+`STORAGE_URL` to an address both browsers and the containers can reach (with
+TLS if the site has it) when browsers do not reach the host itself. `garage-init` grants every bucket a CORS
 rule for `STORAGE_CORS_ORIGINS` (default `*` - the presigned URL is the access
 control; narrow it for a store reachable beyond the host).
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -30,11 +30,11 @@ This command starts:
 The checkout is mounted read-only and synchronized into the development
 container. Editing the host working tree still triggers hot reload.
 
-Browser-facing file flows use presigned URLs against the store itself, which
-is published on port 3900 (`STORAGE_PORT`) under its own name,
-`http://cbk-storage.localhost:3900` - a `*.localhost` name browsers resolve to
-loopback with no DNS setup, like the relay and app shells. Set `STORAGE_URL`
-when the browser reaches the machine by another address.
+File flows use presigned URLs against the store itself, published on port 3900
+under its own name, `http://cbk-storage.localhost:3900` - a `*.localhost` name
+browsers resolve to loopback with no DNS setup, like the relay and app shells,
+and an alias of the `garage` service inside the Compose network so the
+application reaches the same URLs.
 
 No hosted account, billing configuration or vendor credential is required to
 boot. Model-backed agent responses require at least one model provider key.


### PR DESCRIPTION
Automated release from monorepo.

Pushed from `platform` on branch `next` → `main`.

refactor: update storage service configuration and documentation for consistency