### PR TITLE
Release platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ here. The release version is defined in the workspace root `package.json`.
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-09-10
+
+### Fixed
+
+- Listen on the published application and relay ports inside the Community
+  and Studio containers. The application reaches itself through the address a
+  request arrived on, so publishing `31000` in front of a container listening
+  on `3000` refused every server-side API call in Studio with
+  `ECONNREFUSED 127.0.0.1:31000`, and the same happened to any Community
+  instance moved with `PLATFORM_PORT`.
+
+### Changed
+
+- Bill GLM-5.3 through Vercel AI Gateway at the standard rate again, matching
+  the gateway catalogue after the launch discount ended.
+
 ## [0.3.1] - 2026-09-10
 
 ### Added

--- a/docker/distro/community/compose.yml
+++ b/docker/distro/community/compose.yml
@@ -120,14 +120,17 @@ services:
   platform:
     image: ${PLATFORM_IMAGE:-ghcr.io/chatbotkit/platform-community-app:next}
     ports:
-      # @note PLATFORM_PORT moves the published side, the container keeps 3000
-      - '${PLATFORM_PORT:-3000}:3000'
+      # @note the same port inside and out, like the store: the application
+      # reaches itself through the address a request arrived on, so a
+      # published port the container does not listen on refuses its own
+      # calls. PLATFORM_PORT and RELAY_PORT therefore move both sides
+      - '${PLATFORM_PORT:-3000}:${PLATFORM_PORT:-3000}'
       # @note the built-in realtime relay - see RELAY_URL below
-      - '${RELAY_PORT:-3001}:3001'
+      - '${RELAY_PORT:-3001}:${RELAY_PORT:-3001}'
     environment:
       <<: *storage-env
       NODE_ENV: production
-      PORT: 3000
+      PORT: ${PLATFORM_PORT:-3000}
       SITE_URL: *site-url
       STATIC_URL: ${STATIC_URL:-}
       API_URL: ${API_URL:-}
@@ -138,7 +141,7 @@ services:
       # process hosts itself on RELAY_PORT. Both that process and a host
       # browser dial RELAY_URL, so loopback serves both; a browser elsewhere
       # needs an address it can reach instead (and TLS if the site has it)
-      RELAY_PORT: 3001
+      RELAY_PORT: ${RELAY_PORT:-3001}
       RELAY_URL: *relay-url
       # @note host routing reads its settings at server startup; recreate the
       # container to change domains without rebuilding the image. See x-cbk
@@ -197,7 +200,7 @@ services:
           'CMD',
           'node',
           '-e',
-          "fetch('http://localhost:3000/').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))",
+          "fetch('http://localhost:' + process.env.PORT + '/').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))",
         ]
       interval: 30s
       timeout: 10s

--- a/docker/distro/studio/compose.yml
+++ b/docker/distro/studio/compose.yml
@@ -27,8 +27,9 @@
 # `docker compose config --format json` rather than assuming a port.
 #
 # Studio publishes on 31000, 31001 and 31900 rather than Community's 3000
-# family: it runs beside whatever a developer already has on 3000, and the
-# published ports are the only difference - every container keeps its port.
+# family: it runs beside whatever a developer already has on 3000. The
+# containers listen on the same ports they publish, so every address in the
+# manifest is valid from inside the network as well as from the host.
 #
 # One folder per package flavor lives under docker/distro/. Each publishes as
 # ghcr.io/chatbotkit/platform-<flavor>, pinned by CI to the matching
@@ -124,16 +125,18 @@ services:
   platform:
     image: ${PLATFORM_IMAGE:-ghcr.io/chatbotkit/platform-studio-app:next}
     ports:
-      # @note studio trusts the local user, so its ports stay on loopback;
-      # PLATFORM_PORT moves the published side, the container keeps 3000.
-      # Same for the relay (RELAY_PORT, container 3001) below
-      - '127.0.0.1:${PLATFORM_PORT:-31000}:3000'
+      # @note studio trusts the local user, so its ports stay on loopback
+      # @note the same port inside and out, like the store: the application
+      # reaches itself through the address a request arrived on, so a
+      # published port the container does not listen on refuses its own
+      # calls. PLATFORM_PORT and RELAY_PORT therefore move both sides
+      - '127.0.0.1:${PLATFORM_PORT:-31000}:${PLATFORM_PORT:-31000}'
       # @note the built-in realtime relay - see RELAY_URL below
-      - '127.0.0.1:${RELAY_PORT:-31001}:3001'
+      - '127.0.0.1:${RELAY_PORT:-31001}:${RELAY_PORT:-31001}'
     environment:
       <<: *storage-env
       NODE_ENV: production
-      PORT: 3000
+      PORT: ${PLATFORM_PORT:-31000}
       SITE_URL: *site-url
       STATIC_URL: ${STATIC_URL:-}
       API_URL: ${API_URL:-}
@@ -146,7 +149,7 @@ services:
       # process hosts itself on RELAY_PORT. Both that process and a host
       # browser dial RELAY_URL, so loopback serves both; a browser elsewhere
       # needs an address it can reach instead (and TLS if the site has it)
-      RELAY_PORT: 3001
+      RELAY_PORT: ${RELAY_PORT:-31001}
       RELAY_URL: *relay-url
       # @note host routing reads its settings at server startup; recreate the
       # container to change domains without rebuilding the image. See x-cbk
@@ -205,7 +208,7 @@ services:
           'CMD',
           'node',
           '-e',
-          "fetch('http://localhost:3000/').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))",
+          "fetch('http://localhost:' + process.env.PORT + '/').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))",
         ]
       interval: 30s
       timeout: 10s

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -248,8 +248,10 @@ docker compose -f oci://ghcr.io/chatbotkit/platform-studio:latest up
 Studio publishes on its own port family - `31000` for the application,
 `31001` for the relay and `31900` for the object store - so it runs beside
 whatever a developer already has on Community's `3000`, `3001` and `3900`, and
-the two stacks can share a host. Only the published side differs; the
-containers keep their ports. The Studio app learns where the stack answers
+the two stacks can share a host. The containers listen on the ports they
+publish: the application reaches itself and its relay through the addresses
+in the manifest, so a port that differs inside and out would refuse the
+application's own calls. The Studio app learns where the stack answers
 from its [endpoint manifest](#endpoint-manifest) rather than a fixed port.
 
 A PostgreSQL flavor would swap the database column only; the other services

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "platform",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": true,
   "license": "Apache-2.0",
   "packageManager": "pnpm@11.24.0",

--- a/platform/config/models.ts
+++ b/platform/config/models.ts
@@ -4790,11 +4790,11 @@ export const vercelLanguageModels: Record<
         maxOutputTokens: 128_000,
 
         pricing: {
-          tokenRatio: 0.1222,
-          inputTokenRatio: 0.05,
-          outputTokenRatio: 0.1222,
-          inputPrice: 0.7,
-          outputPrice: 2.2,
+          tokenRatio: 0.2444,
+          inputTokenRatio: 0.1,
+          outputTokenRatio: 0.2444,
+          inputPrice: 1.4,
+          outputPrice: 4.4,
         },
 
         interactionMaxMessages: DEFAULT_INTERACTION_MAX_MESSAGES,

--- a/platform/lib/model.provider.vercel.utest.js
+++ b/platform/lib/model.provider.vercel.utest.js
@@ -743,12 +743,12 @@ describeIfConfigured('listModels', () => {
       {
         // MiniMax documents up to 1M context, but the gateway lists 512k.
         prefix: 'minimax-m3: maxTokens',
-        expires: '2026-09-11',
+        expires: '2026-10-11',
       },
       {
         // 1M context minus the documented 128k maximum output leaves 872k input.
         prefix: 'minimax-m3: maxInputTokens',
-        expires: '2026-09-11',
+        expires: '2026-10-11',
       },
     ]
 


### PR DESCRIPTION
Automated release from monorepo.

Pushed from `platform` on branch `next` → `main`.

chore(release): bump version to 0.3.2 and update changelog for recent fixes and changes (+1 more)

- chore(release): bump version to 0.3.2 and update changelog for recent fixes and changes
- feat: update pricing model for Vercel AI Gateway and adjust expiration dates in tests