### PR TITLE
Release platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ here. The release version is defined in the workspace root `package.json`.
 
 ## [Unreleased]
 
+## [0.3.3] - 2026-09-10
+
+### Fixed
+
+- Let the platform fetch its own URLs on the Community and Studio stacks.
+  The egress boundary refused every loopback and private destination outside
+  development, and those stacks run the production build on loopback, so
+  proxied images, attachments and presigned objects failed with `egress to
+  127.0.0.1 is not allowed`. The boundary now recognises the deployment
+  itself: the configured site, static, widget, API and app shell origins
+  connect unchecked, and where the site lives on loopback so does every
+  loopback and `*.localhost` destination. Other private addresses stay
+  refused, and a hosted deployment's public origins gain nothing.
+- Stop the upgrade page from offering a checkout the billing API refuses.
+  An account that already holds a subscription - live, or lapsed after a
+  failed payment - is sent to the billing portal to change it, a lapsed one
+  is told its payment needs fixing, and a child account is told billing
+  belongs to the owner. A refused checkout now surfaces its message instead
+  of the button silently doing nothing. Billing modules gain
+  `hasOpenSubscription` on the subscription model.
+- Retry a sandbox command that the AgentOS runtime refused to start because it
+  was still tearing down the previous command after a timeout. The refusal
+  surfaced as exit 127 with empty output on the first command after any
+  timed-out one, most often under load.
+
 ## [0.3.2] - 2026-09-10
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "platform",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "private": true,
   "license": "Apache-2.0",
   "packageManager": "pnpm@11.24.0",

--- a/packages/billing-spec/src/index.ts
+++ b/packages/billing-spec/src/index.ts
@@ -75,6 +75,14 @@ export interface SubscriptionModel {
   hasSubscription(user: SubscriptionHolder): boolean
 
   /**
+   * Whether the account holds a subscription the provider still keeps open,
+   * live or not - a lapsed payment leaves one open. An open subscription is
+   * changed through the billing portal; a fresh checkout is refused against
+   * it.
+   */
+  hasOpenSubscription(user: SubscriptionHolder): boolean
+
+  /**
    * Whether the account has ever consumed its trial - one per account,
    * regardless of the plan it ran on or how the trial ended.
    */

--- a/packages/billing/src/model.ts
+++ b/packages/billing/src/model.ts
@@ -32,6 +32,10 @@ export function createSubscriptionModel(
       return grantedPlan(user.email) !== undefined
     },
 
+    hasOpenSubscription() {
+      return false
+    },
+
     hasTrialed() {
       return false
     },

--- a/packages/sandbox/src/conflict.test.js
+++ b/packages/sandbox/src/conflict.test.js
@@ -1,0 +1,107 @@
+// @note the runtime is faked here, and only here: the conflict below is what
+// the sidecar answers while it is still tearing down a timed-out command, and
+// how long that takes depends on machine load, so the real runtime cannot be
+// made to answer it on cue. The retry is what makes the sequence in
+// index.test.js dependable, and this pins the retry itself.
+
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { jest } from '@jest/globals'
+
+const dataDir = mkdtempSync(join(tmpdir(), 'sandbox-conflict-test-'))
+
+process.env.SANDBOX_DATA_DIR = dataDir
+
+const CONFLICT =
+  'ERR_AGENTOS_VM_EXECUTION_CONFLICT: WebAssembly execution state for VM vm-1 is already in use during start WebAssembly execution'
+
+const conflict = () => ({ outcome: 'failed', error: { message: CONFLICT } })
+
+const succeeded = (stdout) => ({ outcome: 'succeeded', exitCode: 0, stdout })
+
+/** Answers per command, consumed front to back; the last answer repeats. */
+const answers = new Map()
+
+const exec = jest.fn(async (cmd) => {
+  const queue = answers.get(cmd) ?? [succeeded('')]
+
+  return queue.length > 1 ? queue.shift() : queue[0]
+})
+
+const execute = jest.fn(async () => succeeded(''))
+
+jest.unstable_mockModule('@rivet-dev/agentos-core', () => ({
+  AgentOs: {
+    create: async () => ({
+      process: { exec },
+      javascript: { execute },
+      python: {
+        execute: async () => ({
+          outcome: 'failed',
+          error: { message: 'ENOENT: command not found: python' },
+        }),
+      },
+      contexts: { reset: async () => {} },
+      createContext: async () => {},
+      filesystem: {},
+      dispose: async () => {},
+    }),
+  },
+  createHostDirBackend: () => ({}),
+}))
+
+const { default: provider, reset } = await import('./index.ts')
+
+jest.setTimeout(30_000)
+
+afterEach(() => {
+  answers.clear()
+  exec.mockClear()
+  execute.mockClear()
+})
+
+afterAll(async () => {
+  await reset()
+
+  rmSync(dataDir, { recursive: true, force: true })
+})
+
+it('runs a command again once the runtime lets go of the previous one', async () => {
+  answers.set('echo recovered', [conflict(), conflict(), succeeded('recovered\n')])
+
+  const result = await provider.exec({ sandboxId: 'a', cmd: 'echo recovered' })
+
+  expect(result.exitCode).toBe(0)
+  expect(result.stdout).toBe('recovered\n')
+  expect(exec.mock.calls.filter(([cmd]) => cmd === 'echo recovered')).toHaveLength(3)
+})
+
+it('does the same for code in a session', async () => {
+  execute
+    .mockResolvedValueOnce(conflict())
+    .mockResolvedValueOnce(succeeded('1\n'))
+
+  const result = await provider.runCode({
+    sandboxId: 'a',
+    language: 'javascript',
+    code: 'console.log(1)',
+  })
+
+  expect(result.stdout).toBe('1\n')
+  expect(execute).toHaveBeenCalledTimes(2)
+})
+
+it('reports a conflict that never clears as a command that could not run', async () => {
+  answers.set('echo stuck', [conflict()])
+
+  const started = Date.now()
+
+  const result = await provider.exec({ sandboxId: 'a', cmd: 'echo stuck' })
+
+  expect(result.exitCode).toBe(127)
+  expect(result.error).toMatch(/ERR_AGENTOS_VM_EXECUTION_CONFLICT/)
+  expect(Date.now() - started).toBeGreaterThanOrEqual(4_500)
+  expect(exec.mock.calls.filter(([cmd]) => cmd === 'echo stuck').length).toBeGreaterThan(10)
+})

--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -564,6 +564,50 @@ function toRunResult(
   return { exitCode: result.exitCode, stdout, stderr }
 }
 
+/**
+ * How long a VM is given to let go of a killed command before the next one is
+ * reported as unable to start.
+ */
+const CONFLICT_SETTLE_MS = 5_000
+
+const CONFLICT_RETRY_INTERVAL_MS = 50
+
+/**
+ * @note the sidecar tears a timed-out process down after it has already
+ * answered `timed_out`, and until that finishes a new command on the VM is
+ * refused at start with an execution conflict - reported as a result, not a
+ * rejection. The queue rules out overlap of this module's own making, so a
+ * conflict can only be that teardown, and the command has not run, so running
+ * it again is safe. Under load the window is long enough that a conversation
+ * would otherwise see `command not found`-shaped failures right after a
+ * timeout.
+ */
+function isExecutionConflict(result: ExecutionResult): boolean {
+  return (
+    result.outcome !== 'succeeded' &&
+    result.exitCode === undefined &&
+    /ERR_AGENTOS_VM_EXECUTION_CONFLICT/.test(result.error?.message ?? '')
+  )
+}
+
+async function runSettled(
+  run: () => Promise<ExecutionResult>
+): Promise<ExecutionResult> {
+  const deadline = Date.now() + CONFLICT_SETTLE_MS
+
+  for (;;) {
+    const result = await run()
+
+    if (!isExecutionConflict(result) || Date.now() >= deadline) {
+      return result
+    }
+
+    await new Promise((resolve) =>
+      setTimeout(resolve, CONFLICT_RETRY_INTERVAL_MS)
+    )
+  }
+}
+
 // --- interpreters ---
 
 let pythonAvailable: Promise<boolean> | undefined
@@ -684,9 +728,11 @@ async function interpret(
   }
 
   const execute = () =>
-    language === 'python'
-      ? vm.python.execute(code, executionOptions)
-      : vm.javascript.execute(code, executionOptions)
+    runSettled(() =>
+      language === 'python'
+        ? vm.python.execute(code, executionOptions)
+        : vm.javascript.execute(code, executionOptions)
+    )
 
   let result: ExecutionResult
 
@@ -763,12 +809,14 @@ async function exec(options: SandboxExecOptions): Promise<SandboxExecResult> {
       // while providing none, and worse, a lingering shell is exactly the
       // process the sidecar hangs on - see the module header.
 
-      const result = await vm.process.exec(cmd, {
-        cwd: WORKSPACE,
-        output: { capture: 'all' },
-        ...(env ? { env } : {}),
-        ...(timeout ? { timeoutMs: timeout } : {}),
-      })
+      const result = await runSettled(() =>
+        vm.process.exec(cmd, {
+          cwd: WORKSPACE,
+          output: { capture: 'all' },
+          ...(env ? { env } : {}),
+          ...(timeout ? { timeoutMs: timeout } : {}),
+        })
+      )
 
       return { ...toRunResult(result, timeout), mountedPaths: entry.mountedPaths }
     }

--- a/platform/components/UpgradePlans.jsx
+++ b/platform/components/UpgradePlans.jsx
@@ -98,15 +98,26 @@ function PlanBadge({ children }) {
 // nothing of it rides in the client bundle. `subscriptions.pricing` carries
 // null for a plan that is not self-serve: Infinity does not survive
 // serialization, so it is restored here.
+//
+// Whether the cards may check out is decided there too: a child account
+// never bills (`billable`), and an account already holding a subscription
+// (`openSubscription`) changes it through the billing portal - a fresh
+// checkout is refused against it, and a lapsed one (`lapsed`) needs its
+// payment fixed there first.
 export default function UpgradePlans({
   currentPlan,
   limits,
   subscriptions,
   trialPlans,
+  billable = true,
+  openSubscription = false,
+  lapsed = false,
 }) {
   const router = useRouter()
 
-  const { fetch } = useFetch()
+  // @note the checkout API refuses with a message the user has to see -
+  // without the failure toast a refused click reads as a dead button
+  const { fetch } = useFetch({ loadingMessage: true, failureMessage: true })
 
   // @note the matrix opens on what differs - that is the comparison - and
   // expands to the full catalogue on demand
@@ -165,6 +176,16 @@ export default function UpgradePlans({
     }
   }
 
+  async function goToPortal() {
+    const { data, error } = await fetch('/api/billing/session', {
+      data: { returnTo: router.asPath },
+    })
+
+    if (!error) {
+      router.push(data.redirectUrl)
+    }
+  }
+
   if (!rungs.some(({ current }) => !current)) {
     // @note a deployment with nothing left to sell this user - already on the
     // top plan, or selling nothing self-serve
@@ -191,9 +212,37 @@ export default function UpgradePlans({
 
   return (
     <div className="space-y-16">
+      {!billable ? (
+        <div className="rounded-lg border border-gray-200 p-4 text-sm dark:border-gray-800">
+          Billing for this account is managed by the owner of the account.
+          Ask them to change the plan.
+        </div>
+      ) : lapsed ? (
+        <div className="flex flex-wrap items-center justify-between gap-4 rounded-lg border border-gray-200 p-4 text-sm dark:border-gray-800">
+          <div>
+            Your subscription is not active. This usually means the latest
+            payment did not go through. Update your payment details in the
+            billing portal to restore your plan.
+          </div>
+
+          <button
+            type="button"
+            onClick={goToPortal}
+            className="rounded-lg bg-gray-900 px-4 py-2 text-sm font-bold text-white dark:bg-white dark:text-black"
+          >
+            Manage billing
+          </button>
+        </div>
+      ) : null}
+
       <div className="grid gap-6 pt-3 sm:grid-cols-2 lg:grid-cols-3">
         {rungs.map(({ plan, label, price, current, selfServe }) => {
-          const trial = selfServe && !current && trialPlans?.includes(plan)
+          // @note no trial on top of a subscription the account already holds
+          const trial =
+            selfServe &&
+            !current &&
+            !openSubscription &&
+            trialPlans?.includes(plan)
           const featured = !current && plan === featuredPlan
 
           const entitlements = headlineEntitlements(limits?.[plan])
@@ -245,10 +294,16 @@ export default function UpgradePlans({
                 <div className="mt-8 w-full rounded-lg border border-gray-200 px-4 py-2 text-center text-sm font-bold text-gray-400 dark:border-gray-800 dark:text-gray-600">
                   Your plan
                 </div>
+              ) : !billable ? (
+                <div className="mt-8 w-full rounded-lg border border-gray-200 px-4 py-2 text-center text-sm font-bold text-gray-400 dark:border-gray-800 dark:text-gray-600">
+                  Managed by the owner
+                </div>
               ) : selfServe ? (
                 <button
                   type="button"
-                  onClick={() => goToCheckout(plan, trial)}
+                  onClick={() =>
+                    openSubscription ? goToPortal() : goToCheckout(plan, trial)
+                  }
                   className="mt-8 w-full rounded-lg bg-gray-900 px-4 py-2 text-sm font-bold text-white dark:bg-white dark:text-black"
                 >
                   {trial

--- a/platform/components/UpgradePlans.utest.jsx
+++ b/platform/components/UpgradePlans.utest.jsx
@@ -139,6 +139,81 @@ describe('UpgradePlans', () => {
     })
   })
 
+  describe('refused checkout', () => {
+    // @note the checkout API refuses with a message a user has to see - an
+    // account that already holds a subscription, one whose card was declined -
+    // and the hook only surfaces it when asked to. Without this the button
+    // reads as doing nothing.
+    it('surfaces the failure message of a refused checkout', () => {
+      render(<UpgradePlans subscriptions={subscriptions} trialPlans={trialPlans} currentPlan="free" limits={limits} />)
+
+      expect(useFetch).toHaveBeenCalledWith(
+        expect.objectContaining({ failureMessage: true })
+      )
+    })
+  })
+
+  describe('open subscription', () => {
+    // @note an account that already holds a subscription changes it through
+    // the billing portal - a fresh checkout is refused against it - so every
+    // card sends there, and no trial is offered on top of a subscription
+    it('sends every switch to the billing portal instead of checkout', async () => {
+      const fetch = jest.fn().mockResolvedValue({
+        data: { redirectUrl: 'https://portal.example.com/session' },
+      })
+
+      const push = jest.fn()
+
+      useFetch.mockReturnValue({ fetch })
+      useRouter.mockReturnValue({ push, asPath: '/billing/upgrade' })
+
+      render(<UpgradePlans subscriptions={subscriptions} trialPlans={trialPlans} currentPlan="basic" limits={limits} openSubscription />)
+
+      expect(screen.queryByText('Start 7-day trial')).not.toBeInTheDocument()
+
+      fireEvent.click(screen.getByText('Switch to Pro'))
+
+      await waitFor(() => {
+        expect(fetch).toHaveBeenCalledWith('/api/billing/session', {
+          data: { returnTo: '/billing/upgrade' },
+        })
+      })
+
+      expect(fetch).not.toHaveBeenCalledWith('/api/billing/checkout', expect.anything())
+
+      await waitFor(() => {
+        expect(push).toHaveBeenCalledWith('https://portal.example.com/session')
+      })
+    })
+
+    it('explains a lapsed subscription and offers the portal', () => {
+      render(<UpgradePlans subscriptions={subscriptions} trialPlans={trialPlans} currentPlan="free" limits={limits} openSubscription lapsed />)
+
+      expect(screen.getByText(/subscription is not active/i)).toBeInTheDocument()
+      expect(screen.getByText('Manage billing')).toBeInTheDocument()
+    })
+
+    it('does not mention a lapse on a live subscription', () => {
+      render(<UpgradePlans subscriptions={subscriptions} trialPlans={trialPlans} currentPlan="basic" limits={limits} openSubscription />)
+
+      expect(screen.queryByText(/subscription is not active/i)).not.toBeInTheDocument()
+    })
+  })
+
+  describe('account managed by its owner', () => {
+    // @note a child account never bills - the checkout API refuses it - so
+    // the cards carry no call to action and the page says who does
+    it('renders no checkout and says billing belongs to the owner', () => {
+      render(<UpgradePlans subscriptions={subscriptions} trialPlans={trialPlans} currentPlan="basic" limits={limits} billable={false} />)
+
+      expect(screen.queryByRole('button', { name: /switch to|trial/i })).not.toBeInTheDocument()
+      expect(screen.getByText(/billing for this account is managed by the owner/i)).toBeInTheDocument()
+
+      // the comparison still renders - the plans are still worth reading
+      expect(screen.getByText('Compare plans')).toBeInTheDocument()
+    })
+  })
+
   describe('nothing to sell', () => {
     // @note a truly planless deployment never reaches the component - the
     // page 404s from getServerSideProps - so this covers the sellable

--- a/platform/lib/billing.core.ts
+++ b/platform/lib/billing.core.ts
@@ -35,6 +35,7 @@ export const {
   recordedPlanName, // @todo must be only available on chatbotkit-internal/billing as it is an internal thing
 
   hasSubscription,
+  hasOpenSubscription,
   hasTrialed,
 
   userToPlan,

--- a/platform/lib/egress.core.ts
+++ b/platform/lib/egress.core.ts
@@ -18,18 +18,25 @@
 // platform's ordinary fetch path.
 //
 // There is no allowlist and no switch: a request to an internal address is not
-// something the application ever makes on a user's or model's behalf.
-// Development is the one exemption, because that is where the application
-// itself lives on localhost.
+// something the application ever makes on a user's or model's behalf. The one
+// exemption is the deployment itself. The platform fetches its own URLs like
+// any other - proxied images, attachments, presigned objects - so the origins
+// the operator configured (site, static, widget, API, app shells) connect
+// unchecked, and where the site itself lives on loopback (development, the
+// Community and Studio stacks) so does every loopback and `*.localhost`
+// destination, which is where such a stack's store and relay answer. Being
+// derived from configuration, that is not a switch: a hosted deployment's
+// origins are public and gain nothing.
+import { appLabsOrigin, appMainOrigin } from '@/config/origins'
+import { apiUrl, siteUrl, staticUrl, widgetUrl } from '@/config/site'
+
+import { isDevelopment } from '@/lib/env'
+import { isForbiddenAddress, isIpAddress, isLoopbackAddress } from '@/lib/ip'
 
 import { lookup as dnsLookup } from 'node:dns'
 import type { LookupAddress, LookupOptions } from 'node:dns'
-
 import type * as Undici from 'undici'
 import type { Agent, Dispatcher } from 'undici'
-
-import { isDevelopment } from '@/lib/env'
-import { isForbiddenAddress, isIpAddress } from '@/lib/ip'
 
 export class EgressError extends Error {
   readonly egress = true as const
@@ -107,36 +114,140 @@ export function guardedLookup(
 }
 
 /**
+ * Whether a hostname names the machine itself: `localhost`, a `*.localhost`
+ * name (resolved to loopback by browsers and the Compose stacks alike) or a
+ * loopback address.
+ */
+export function isLoopbackHostname(hostname: string): boolean {
+  const name = hostname.toLowerCase()
+
+  return (
+    name === 'localhost' ||
+    name.endsWith('.localhost') ||
+    isLoopbackAddress(name)
+  )
+}
+
+export interface SelfDeployment {
+  /** `hostname:port` of every origin the deployment answers on */
+  hosts: Set<string>
+  /** whether the site itself lives on loopback */
+  loopback: boolean
+}
+
+function defaultPort(protocol: string): number {
+  return protocol === 'https:' || protocol === 'wss:' ? 443 : 80
+}
+
+function toHostKey(hostname: string, port: number): string {
+  return `${hostname.replace(/^\[|\]$/g, '').toLowerCase()}:${port}`
+}
+
+/**
+ * The deployment as its configuration describes it. Read when a dispatcher
+ * is created, so it reflects the origins the process started with.
+ */
+export function getSelfDeployment(): SelfDeployment {
+  const hosts = new Set<string>()
+
+  for (const origin of [
+    siteUrl,
+    staticUrl,
+    widgetUrl,
+    apiUrl,
+    appMainOrigin,
+    appLabsOrigin,
+  ]) {
+    if (!origin) {
+      continue
+    }
+
+    try {
+      const url = new URL(origin)
+
+      hosts.add(
+        toHostKey(url.hostname, Number(url.port) || defaultPort(url.protocol))
+      )
+    } catch {
+      // not a url - not a host
+    }
+  }
+
+  let loopback = false
+
+  try {
+    loopback = isLoopbackHostname(new URL(siteUrl).hostname)
+  } catch {
+    // not a url - not loopback
+  }
+
+  return { hosts, loopback }
+}
+
+/**
+ * Whether a connection is to the deployment itself and so exempt from the
+ * boundary: one of its configured hosts, or any loopback destination where
+ * the site itself lives on loopback.
+ */
+export function isSelfDestination(
+  hostname: string,
+  port: number,
+  self: SelfDeployment
+): boolean {
+  if (self.hosts.has(toHostKey(hostname, port))) {
+    return true
+  }
+
+  return self.loopback && isLoopbackHostname(hostname.replace(/^\[|\]$/g, ''))
+}
+
+/**
  * Creates the dispatcher every guarded request goes through. Literal
  * addresses are checked in the connector - `net.connect` does not consult
  * `lookup` for them - and names are checked by `guardedLookup` at resolution.
  * Because undici follows redirects through the same dispatcher, each hop is
- * checked the same way.
+ * checked the same way. Connections to the deployment itself skip both
+ * checks and resolve through the plain resolver, since on the Compose stacks
+ * its own names answer from the private network.
  */
 export function createEgressDispatcher(
-  options: Agent.Options = {}
+  options: Agent.Options = {},
+  self: SelfDeployment = getSelfDeployment()
 ): Dispatcher {
   // @note loaded here rather than at the top: undici is server-only and
   // this module is imported by code whose tests run under jsdom
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { Agent, buildConnector } = require('undici') as typeof Undici
 
+  const connectOptions =
+    typeof options.connect === 'object' ? options.connect : {}
+
   const connect = buildConnector({
-    ...(typeof options.connect === 'object' ? options.connect : {}),
+    ...connectOptions,
     lookup: guardedLookup,
+  })
+
+  const connectSelf = buildConnector({
+    ...connectOptions,
+    lookup: dnsLookup as typeof guardedLookup,
   })
 
   return new Agent({
     ...options,
 
     connect(connectOptions, callback) {
-      const { hostname } = connectOptions
+      const { hostname, port, protocol } = connectOptions
+
+      if (
+        isSelfDestination(hostname, Number(port) || defaultPort(protocol), self)
+      ) {
+        connectSelf(connectOptions, callback)
+
+        return
+      }
 
       if (isIpAddress(hostname) && isForbiddenAddress(hostname)) {
-        callback(
-          new EgressError(hostname, 'not a public address'),
-          null
-        )
+        callback(new EgressError(hostname, 'not a public address'), null)
 
         return
       }

--- a/platform/lib/egress.core.utest.js
+++ b/platform/lib/egress.core.utest.js
@@ -9,11 +9,25 @@ import {
   EgressError,
   createEgressDispatcher,
   getEgressDispatcher,
+  getSelfDeployment,
   guardedLookup,
+  isSelfDestination,
 } from '@/lib/egress.core'
 
 jest.mock('node:dns', () => ({
   lookup: jest.fn(),
+}))
+
+jest.mock('@/config/site', () => ({
+  siteUrl: 'https://cbk.example',
+  staticUrl: 'https://static.cbk.example',
+  widgetUrl: 'https://cbk.example',
+  apiUrl: 'https://api.cbk.example',
+}))
+
+jest.mock('@/config/origins', () => ({
+  appMainOrigin: 'https://apps.cbk.example',
+  appLabsOrigin: undefined,
 }))
 
 jest.mock('@/lib/env', () => ({
@@ -226,6 +240,200 @@ describe('createEgressDispatcher', () => {
     )
 
     await guardedDispatcher.close()
+  })
+})
+
+describe('getSelfDeployment', () => {
+  const site = jest.requireMock('@/config/site')
+
+  afterEach(() => {
+    site.siteUrl = 'https://cbk.example'
+  })
+
+  it('lists every configured origin as host:port', () => {
+    const self = getSelfDeployment()
+
+    expect([...self.hosts].sort()).toEqual([
+      'api.cbk.example:443',
+      'apps.cbk.example:443',
+      'cbk.example:443',
+      'static.cbk.example:443',
+    ])
+    expect(self.loopback).toBe(false)
+  })
+
+  it('marks a site on a *.localhost name as living on loopback', () => {
+    site.siteUrl = 'http://cbk.localhost:31000'
+
+    const self = getSelfDeployment()
+
+    expect(self.hosts).toContain('cbk.localhost:31000')
+    expect(self.loopback).toBe(true)
+  })
+})
+
+describe('isSelfDestination', () => {
+  it('matches a configured host on its port only', () => {
+    const self = { hosts: new Set(['10.0.0.5:3000']), loopback: false }
+
+    expect(isSelfDestination('10.0.0.5', 3000, self)).toBe(true)
+    expect(isSelfDestination('10.0.0.5', 80, self)).toBe(false)
+    expect(isSelfDestination('10.0.0.6', 3000, self)).toBe(false)
+  })
+
+  it('matches a bracketed IPv6 host either way', () => {
+    const self = { hosts: new Set(['::1:31000']), loopback: false }
+
+    expect(isSelfDestination('::1', 31000, self)).toBe(true)
+    expect(isSelfDestination('[::1]', 31000, self)).toBe(true)
+  })
+
+  it('treats loopback destinations as self only where the site is loopback', () => {
+    const local = { hosts: new Set(['cbk.localhost:31000']), loopback: true }
+    const hosted = { hosts: new Set(['cbk.example:443']), loopback: false }
+
+    for (const hostname of ['127.0.0.1', '::1', 'localhost', 'cbk-storage.localhost']) {
+      expect({ hostname, self: isSelfDestination(hostname, 31900, local) }).toEqual({ hostname, self: true })
+      expect({ hostname, self: isSelfDestination(hostname, 31900, hosted) }).toEqual({ hostname, self: false })
+    }
+
+    // @note private is not loopback: the rest of the stack's network stays out
+    expect(isSelfDestination('172.18.0.5', 31900, local)).toBe(false)
+    expect(isSelfDestination('169.254.169.254', 80, local)).toBe(false)
+  })
+})
+
+describe('createEgressDispatcher for the deployment itself', () => {
+  const http = jest.requireActual('node:http')
+
+  let server
+  let port
+
+  beforeAll(async () => {
+    server = http.createServer((req, res) => {
+      res.end('self')
+    })
+
+    await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve))
+
+    port = server.address().port
+  })
+
+  afterAll(async () => {
+    await new Promise((resolve) => server.close(resolve))
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('connects to a configured host even at a loopback address', async () => {
+    const dispatcher = createEgressDispatcher(
+      {},
+      { hosts: new Set([`127.0.0.1:${port}`]), loopback: false }
+    )
+
+    const response = await fetch(`http://127.0.0.1:${port}/`, { dispatcher })
+
+    expect(await response.text()).toBe('self')
+
+    await dispatcher.close()
+  })
+
+  it('refuses the same address where it is not a configured host', async () => {
+    const dispatcher = createEgressDispatcher(
+      {},
+      { hosts: new Set(['cbk.example:443']), loopback: false }
+    )
+
+    const error = await fetch(`http://127.0.0.1:${port}/`, { dispatcher }).then(
+      () => null,
+      (e) => e
+    )
+
+    expect(String(error?.cause?.message)).toMatch(
+      /egress to 127\.0\.0\.1 is not allowed: not a public address/
+    )
+
+    await dispatcher.close()
+  })
+
+  it('connects to any loopback destination where the site lives on loopback', async () => {
+    // @note the Studio case: the site is cbk.localhost, the request arrived
+    // on 127.0.0.1 and the platform fetches the URL it built from that
+    const dispatcher = createEgressDispatcher(
+      {},
+      { hosts: new Set(['cbk.localhost:31000']), loopback: true }
+    )
+
+    const response = await fetch(`http://127.0.0.1:${port}/`, { dispatcher })
+
+    expect(await response.text()).toBe('self')
+
+    await dispatcher.close()
+  })
+
+  it('resolves a *.localhost name through the plain resolver where the site lives on loopback', async () => {
+    // @note the store's name inside a Compose network answers with a private
+    // address the guarded resolver would refuse
+    lookup.mockImplementation((hostname, options, callback) => {
+      if (options.all) {
+        callback(null, [{ address: '127.0.0.1', family: 4 }])
+      } else {
+        callback(null, '127.0.0.1', 4)
+      }
+    })
+
+    const dispatcher = createEgressDispatcher(
+      {},
+      { hosts: new Set(['cbk.localhost:31000']), loopback: true }
+    )
+
+    const response = await fetch(`http://cbk-storage.localhost:${port}/`, {
+      dispatcher,
+    })
+
+    expect(await response.text()).toBe('self')
+    expect(lookup).toHaveBeenCalledWith(
+      'cbk-storage.localhost',
+      expect.anything(),
+      expect.any(Function)
+    )
+
+    await dispatcher.close()
+  })
+
+  it('still refuses private destinations where the site lives on loopback', async () => {
+    lookup.mockImplementation((hostname, options, callback) => {
+      callback(null, [{ address: '172.18.0.5', family: 4 }])
+    })
+
+    const dispatcher = createEgressDispatcher(
+      {},
+      { hosts: new Set(['cbk.localhost:31000']), loopback: true }
+    )
+
+    const literal = await fetch('http://169.254.169.254/latest/meta-data/', {
+      dispatcher,
+    }).then(
+      () => null,
+      (e) => e
+    )
+    const named = await fetch('http://intranet.attacker.example/', {
+      dispatcher,
+    }).then(
+      () => null,
+      (e) => e
+    )
+
+    expect(String(literal?.cause?.message)).toMatch(
+      /egress to 169\.254\.169\.254 is not allowed: not a public address/
+    )
+    expect(String(named?.cause?.message)).toMatch(
+      /resolves to 172\.18\.0\.5, which is not a public address/
+    )
+
+    await dispatcher.close()
   })
 })
 

--- a/platform/lib/ip.ts
+++ b/platform/lib/ip.ts
@@ -219,3 +219,42 @@ export function isForbiddenAddress(address: string): boolean {
 
   return true
 }
+
+/**
+ * Whether a literal address is loopback: 127/8, `::1`, or their IPv4-mapped
+ * and IPv4-translated IPv6 forms. Brackets and a zone index are stripped
+ * like `isForbiddenAddress` does. Text that is not an address is not
+ * loopback.
+ */
+export function isLoopbackAddress(address: string): boolean {
+  const text = address.replace(/^\[|\]$/g, '').replace(/%.*$/, '')
+
+  const octets = parseIpv4Address(text)
+
+  if (octets) {
+    return octets[0] === 127
+  }
+
+  const groups = parseIpv6Address(text)
+
+  if (!groups) {
+    return false
+  }
+
+  const [g0, g1, g2, g3, g4, g5, g6, g7] = groups
+
+  if (g0 !== 0 || g1 !== 0 || g2 !== 0 || g3 !== 0) {
+    return false
+  }
+
+  if (g4 === 0 && g5 === 0) {
+    return g6 === 0 && g7 === 1
+  }
+
+  // ::ffff:127.x and ::ffff:0:127.x
+  if ((g4 === 0 && g5 === 0xffff) || (g4 === 0xffff && g5 === 0)) {
+    return g6 >> 8 === 127
+  }
+
+  return false
+}

--- a/platform/lib/ip.utest.js
+++ b/platform/lib/ip.utest.js
@@ -1,4 +1,4 @@
-import { isForbiddenAddress, isIpAddress } from '@/lib/ip'
+import { isForbiddenAddress, isIpAddress, isLoopbackAddress } from '@/lib/ip'
 
 describe('isIpAddress', () => {
   it.each([
@@ -109,5 +109,33 @@ describe('isForbiddenAddress', () => {
     '[2606:4700:4700::1111]',
   ])('allows public %s', (address) => {
     expect(isForbiddenAddress(address)).toBe(false)
+  })
+})
+
+describe('isLoopbackAddress', () => {
+  it.each([
+    '127.0.0.1',
+    '127.255.255.254',
+    '::1',
+    '[::1]',
+    '::ffff:127.0.0.1',
+    '::ffff:0:127.0.0.1',
+  ])('recognises %s', (address) => {
+    expect(isLoopbackAddress(address)).toBe(true)
+  })
+
+  it.each([
+    '0.0.0.0',
+    '10.0.0.1',
+    '169.254.169.254',
+    '8.8.8.8',
+    '::',
+    '::ffff:10.0.0.1',
+    'fe80::1%eth0',
+    'localhost',
+    'cbk.localhost',
+    '',
+  ])('does not mistake %s for loopback', (address) => {
+    expect(isLoopbackAddress(address)).toBe(false)
   })
 })

--- a/platform/lib/url3.utest.js
+++ b/platform/lib/url3.utest.js
@@ -12,6 +12,13 @@ jest.mock('@/lib/env', () => ({
   isDevelopment: false,
 }))
 
+// @note asserted as a hosted deployment: a site on loopback would make
+// 127.0.0.1 the deployment itself
+jest.mock('@/config/site', () => ({
+  ...jest.requireActual('@/config/site'),
+  siteUrl: 'https://cbk.example',
+}))
+
 describe('getUrlContentType', () => {
   beforeEach(() => {
     jest.clearAllMocks()

--- a/platform/pages/api/auxiliary/dataset/_chunk.utest.js
+++ b/platform/pages/api/auxiliary/dataset/_chunk.utest.js
@@ -63,6 +63,13 @@ jest.mock('@/lib/env', () => ({
   isDevelopment: false,
 }))
 
+// @note asserted as a hosted deployment: a site on loopback would make
+// 127.0.0.1 the deployment itself
+jest.mock('@/config/site', () => ({
+  ...jest.requireActual('@/config/site'),
+  siteUrl: 'https://cbk.example',
+}))
+
 jest.mock('@/lib/egress.fetch', () =>
   jest.fn().mockResolvedValue({
     ok: true,

--- a/platform/pages/api/auxiliary/skillset/ability/chatbotkit/dataset/file/_attach.utest.js
+++ b/platform/pages/api/auxiliary/skillset/ability/chatbotkit/dataset/file/_attach.utest.js
@@ -21,6 +21,13 @@ jest.mock('@/lib/env', () => ({
   isDevelopment: false,
 }))
 
+// @note asserted as a hosted deployment: a site on loopback would make
+// 127.0.0.1 the deployment itself
+jest.mock('@/config/site', () => ({
+  ...jest.requireActual('@/config/site'),
+  siteUrl: 'https://cbk.example',
+}))
+
 jest.mock('@/lib/egress.fetch', () => jest.fn())
 
 jest.mock('@/lib/mime', () => ({

--- a/platform/pages/api/auxiliary/skillset/ability/chatbotkit/url/_git.utest.js
+++ b/platform/pages/api/auxiliary/skillset/ability/chatbotkit/url/_git.utest.js
@@ -22,6 +22,13 @@ jest.mock('@/lib/env', () => ({
   isDevelopment: false,
 }))
 
+// @note asserted as a hosted deployment: a site on loopback would make
+// 127.0.0.1 the deployment itself
+jest.mock('@/config/site', () => ({
+  ...jest.requireActual('@/config/site'),
+  siteUrl: 'https://cbk.example',
+}))
+
 jest.mock('@/lib/egress.fetch', () => jest.fn())
 
 jest.mock('@/lib/auxiliary.handler', () => ({

--- a/platform/pages/api/auxiliary/skillset/ability/chatbotkit/url/_sql.utest.js
+++ b/platform/pages/api/auxiliary/skillset/ability/chatbotkit/url/_sql.utest.js
@@ -24,6 +24,13 @@ jest.mock('@/lib/env', () => ({
   isDevelopment: false,
 }))
 
+// @note asserted as a hosted deployment: a site on loopback would make
+// 127.0.0.1 the deployment itself
+jest.mock('@/config/site', () => ({
+  ...jest.requireActual('@/config/site'),
+  siteUrl: 'https://cbk.example',
+}))
+
 jest.mock('@/lib/egress.fetch', () => jest.fn())
 
 jest.mock('@/lib/auxiliary.duckdb', () => ({

--- a/platform/pages/api/oauth/connection/_callback.utest.js
+++ b/platform/pages/api/oauth/connection/_callback.utest.js
@@ -33,6 +33,13 @@ jest.mock('@/lib/env', () => ({
   isDevelopment: false,
 }))
 
+// @note asserted as a hosted deployment: a site on loopback would make
+// 127.0.0.1 the deployment itself
+jest.mock('@/config/site', () => ({
+  ...jest.requireActual('@/config/site'),
+  siteUrl: 'https://cbk.example',
+}))
+
 jest.mock('@/lib/egress.fetch', () => jest.fn())
 
 jest.mock('@/lib/oauth.connection.idp', () => ({

--- a/platform/pages/api/v1/file/[fileId]/_upload.utest.js
+++ b/platform/pages/api/v1/file/[fileId]/_upload.utest.js
@@ -78,6 +78,13 @@ jest.mock('@/lib/env', () => ({
   isDevelopment: false,
 }))
 
+// @note asserted as a hosted deployment: a site on loopback would make
+// 127.0.0.1 the deployment itself
+jest.mock('@/config/site', () => ({
+  ...jest.requireActual('@/config/site'),
+  siteUrl: 'https://cbk.example',
+}))
+
 jest.mock('@/lib/mime', () => ({
   typeToFileName: jest.fn((type) => `file.${type.split('/')[1] || 'bin'}`),
 }))

--- a/platform/pages/api/v1/image/_edit.utest.js
+++ b/platform/pages/api/v1/image/_edit.utest.js
@@ -68,6 +68,13 @@ jest.mock('@/lib/env', () => ({
   isDevelopment: false,
 }))
 
+// @note asserted as a hosted deployment: a site on loopback would make
+// 127.0.0.1 the deployment itself
+jest.mock('@/config/site', () => ({
+  ...jest.requireActual('@/config/site'),
+  siteUrl: 'https://cbk.example',
+}))
+
 jest.mock('@/lib/egress.fetch', () => jest.fn())
 
 jest.mock('@/lib/image', () => ({

--- a/platform/pages/api/v1/integration/extract/[extractIntegrationId]/_queue.utest.js
+++ b/platform/pages/api/v1/integration/extract/[extractIntegrationId]/_queue.utest.js
@@ -89,6 +89,13 @@ jest.mock('@/lib/env', () => ({
   isDevelopment: false,
 }))
 
+// @note asserted as a hosted deployment: a site on loopback would make
+// 127.0.0.1 the deployment itself
+jest.mock('@/config/site', () => ({
+  ...jest.requireActual('@/config/site'),
+  siteUrl: 'https://cbk.example',
+}))
+
 jest.mock('@/lib/http', () => ({
   normalizeRequest: jest.fn(),
   parseRequest: jest.fn(),

--- a/platform/pages/api/v1/space/[spaceId]/storage/upload/_path.utest.js
+++ b/platform/pages/api/v1/space/[spaceId]/storage/upload/_path.utest.js
@@ -82,6 +82,13 @@ jest.mock('@/lib/env', () => ({
   isDevelopment: false,
 }))
 
+// @note asserted as a hosted deployment: a site on loopback would make
+// 127.0.0.1 the deployment itself
+jest.mock('@/config/site', () => ({
+  ...jest.requireActual('@/config/site'),
+  siteUrl: 'https://cbk.example',
+}))
+
 jest.mock('@/lib/dataurl.parse', () => ({
   parseDataURL: jest.fn(() => ({
     data: Buffer.from('file-content').toString('base64'),

--- a/platform/pages/api/v1/url/_fetch.utest.js
+++ b/platform/pages/api/v1/url/_fetch.utest.js
@@ -38,6 +38,13 @@ jest.mock('@/lib/env', () => ({
   isDevelopment: false,
 }))
 
+// @note asserted as a hosted deployment: a site on loopback would make
+// 127.0.0.1 the deployment itself
+jest.mock('@/config/site', () => ({
+  ...jest.requireActual('@/config/site'),
+  siteUrl: 'https://cbk.example',
+}))
+
 jest.mock('@/lib/joi.handler', () => ({
   __esModule: true,
   default: jest.requireActual('@/lib/joi.schema').default,

--- a/platform/pages/api/v1/webhook/[webhookId]/_queue.utest.js
+++ b/platform/pages/api/v1/webhook/[webhookId]/_queue.utest.js
@@ -35,6 +35,13 @@ jest.mock('@/lib/env', () => ({
   isDevelopment: false,
 }))
 
+// @note asserted as a hosted deployment: a site on loopback would make
+// 127.0.0.1 the deployment itself
+jest.mock('@/config/site', () => ({
+  ...jest.requireActual('@/config/site'),
+  siteUrl: 'https://cbk.example',
+}))
+
 jest.mock('@/lib/http', () => ({
   parseRequest: jest.fn(),
   normalizeRequest: jest.fn(),

--- a/platform/pages/billing/upgrade.jsx
+++ b/platform/pages/billing/upgrade.jsx
@@ -1,6 +1,9 @@
 import limits from '@/config/limits'
 
 import {
+  canDoBilling,
+  hasOpenSubscription,
+  hasSubscription,
   isBillingConfigured,
   isSellable,
   subscriptionsConfig,
@@ -15,7 +18,15 @@ import Dashboard from '@/layouts/Dashboard'
 import Link from '@/components/Link'
 import UpgradePlans from '@/components/UpgradePlans'
 
-export default function Index({ plan, limits, subscriptions, trialPlans }) {
+export default function Index({
+  plan,
+  limits,
+  subscriptions,
+  trialPlans,
+  billable,
+  openSubscription,
+  lapsed,
+}) {
   return (
     <>
       <div className="main-page main-page-6xl">
@@ -35,6 +46,9 @@ export default function Index({ plan, limits, subscriptions, trialPlans }) {
           limits={limits}
           subscriptions={subscriptions}
           trialPlans={trialPlans}
+          billable={billable}
+          openSubscription={openSubscription}
+          lapsed={lapsed}
         />
       </div>
     </>
@@ -78,7 +92,17 @@ export async function getServerSideProps(context) {
     }
   }
 
-  const { plan } = await revealUserPlan(session.user)
+  const { plan, effectiveUser } = await revealUserPlan(session.user)
+
+  // @note whether the cards may check out at all is decided here, against
+  // the account row that holds the subscription: a child account inherits
+  // its parent's, and an account already holding one - live or lapsed - is
+  // refused a fresh checkout and changes it through the portal instead
+  const billable = canDoBilling(session.user)
+
+  const openSubscription = hasOpenSubscription(effectiveUser)
+
+  const lapsed = openSubscription && !hasSubscription(effectiveUser)
 
   return {
     props: makeJsonSafe({
@@ -107,6 +131,10 @@ export async function getServerSideProps(context) {
       },
 
       trialPlans: [...trialPlans],
+
+      billable,
+      openSubscription,
+      lapsed,
     }),
   }
 }

--- a/platform/tests/pages/billing/upgrade.utest.js
+++ b/platform/tests/pages/billing/upgrade.utest.js
@@ -1,0 +1,116 @@
+import { getServerSideProps } from '@/pages/billing/upgrade'
+
+import {
+  canDoBilling,
+  hasOpenSubscription,
+  hasSubscription,
+} from '@/lib/billing.core'
+import { getSoftSession } from '@/lib/session.get'
+import { revealUserPlan } from '@/lib/user.plan'
+
+jest.mock('@/config/limits', () => ({
+  __esModule: true,
+  default: { free: {}, basic: {}, pro: {} },
+}))
+
+jest.mock('@/lib/billing.core', () => ({
+  isSellable: true,
+  isBillingConfigured: jest.fn(() => true),
+  canDoBilling: jest.fn(() => true),
+  hasSubscription: jest.fn(() => false),
+  hasOpenSubscription: jest.fn(() => false),
+  subscriptionsConfig: { trialDays: 7, pricing: { basic: 25, pro: 65 } },
+  trialPlans: ['pro'],
+}))
+
+jest.mock('@/lib/session.get', () => ({
+  getSoftSession: jest.fn(),
+}))
+
+jest.mock('@/lib/user.plan', () => ({
+  revealUserPlan: jest.fn(),
+}))
+
+jest.mock('@/layouts/Dashboard', () => () => null)
+jest.mock('@/components/Link', () => () => null)
+jest.mock('@/components/UpgradePlans', () => () => null)
+
+// @note the page decides server-side whether the cards may check out at
+// all: the account row that holds the subscription is the parent's for a
+// child account, so the billing facts must be read off the effective user,
+// while the child gate reads the session user itself.
+
+describe('/billing/upgrade getServerSideProps', () => {
+  const context = { req: {}, res: {}, resolvedUrl: '/billing/upgrade' }
+
+  const sessionUser = { id: 'child', email: 'member@example.com', parentId: 'owner' }
+
+  const effectiveUser = {
+    id: 'owner',
+    email: 'owner@example.com',
+    billingSubscriptionId: 'price_pro',
+    billingSubscriptionStatus: 'past_due',
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    canDoBilling.mockReturnValue(true)
+    hasSubscription.mockReturnValue(false)
+    hasOpenSubscription.mockReturnValue(false)
+
+    getSoftSession.mockResolvedValue({ user: sessionUser })
+
+    revealUserPlan.mockResolvedValue({ plan: 'free', effectiveUser })
+  })
+
+  it('reads the subscription facts off the effective user', async () => {
+    hasOpenSubscription.mockReturnValue(true)
+    hasSubscription.mockReturnValue(false)
+
+    const { props } = await getServerSideProps(context)
+
+    expect(hasOpenSubscription).toHaveBeenCalledWith(effectiveUser)
+    expect(hasSubscription).toHaveBeenCalledWith(effectiveUser)
+
+    expect(props).toMatchObject({
+      plan: 'free',
+      openSubscription: true,
+      lapsed: true,
+    })
+  })
+
+  it('marks a live subscription as open but not lapsed', async () => {
+    hasOpenSubscription.mockReturnValue(true)
+    hasSubscription.mockReturnValue(true)
+
+    revealUserPlan.mockResolvedValue({
+      plan: 'pro',
+      effectiveUser: { ...effectiveUser, billingSubscriptionStatus: 'active' },
+    })
+
+    const { props } = await getServerSideProps(context)
+
+    expect(props).toMatchObject({ plan: 'pro', openSubscription: true, lapsed: false })
+  })
+
+  it('gates billing on the session user, not the effective one', async () => {
+    canDoBilling.mockReturnValue(false)
+
+    const { props } = await getServerSideProps(context)
+
+    expect(canDoBilling).toHaveBeenCalledWith(sessionUser)
+
+    expect(props).toMatchObject({ billable: false })
+  })
+
+  it('leaves an account without a subscription free to check out', async () => {
+    const { props } = await getServerSideProps(context)
+
+    expect(props).toMatchObject({
+      billable: true,
+      openSubscription: false,
+      lapsed: false,
+    })
+  })
+})


### PR DESCRIPTION
Automated release from monorepo.

Pushed from `platform` on branch `next` → `main`.

feat: update version to 0.3.3 and add changelog entry for recent fixes (+3 more)

- feat: update version to 0.3.3 and add changelog entry for recent fixes
- feat: enhance egress handling for loopback addresses and self-deployment recognition
- feat: add hasOpenSubscription logic and update billing upgrade flow
- feat: implement retry logic for execution conflicts in sandbox commands